### PR TITLE
Support float for polling 'period'

### DIFF
--- a/sleep_inhibitor.py
+++ b/sleep_inhibitor.py
@@ -44,7 +44,7 @@ class Plugin:
         if not path.exists():
             sys.exit(f'{self.name}: "{path}" does not exist')
 
-        period = int(conf.get('period', DEF_PERIOD))
+        period = float(conf.get('period', DEF_PERIOD))
         self.period = period * 60
         self.is_inhibiting = None
 


### PR DESCRIPTION
Sub-minute polling might be desired, and this allows the user to set
sub-minute polling (e.g. `period: 0.5` for 30s polling.)