### PR TITLE
plugins: add plugin for detecting open ssh sessions to the system

### DIFF
--- a/plugins/ssh-session-open
+++ b/plugins/ssh-session-open
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Check for active SSH connections/sessions *to* the system
+
+[ -n "$(pgrep -af 'sshd:.*pts')" ] && exit 254
+exit 0


### PR DESCRIPTION
Suspending while a user is SSH'd to the system may not be desirable, so
here's a plugin to inhibit suspend while an open session is active.