### PR TITLE
plugins: add plugin for Alpine Linux apk

### DIFF
--- a/plugins/apk-running
+++ b/plugins/apk-running
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Check for apk (Alpine [Linux] Package Keeper) activity
+
+[ -n "$(lslocks -rn|grep /lib/apk/db/lock)" ] && exit 254
+exit 0


### PR DESCRIPTION
This plugin adds support for detecting when the package manager for
Alpine Linux (apk) is active (e.g. when installing or upgrading
packages), which is generally a bad time to go to sleep.