### PR TITLE
Support more sshd binary names in the ssh-session-open plugin.

### DIFF
--- a/plugins/ssh-session-open
+++ b/plugins/ssh-session-open
@@ -1,5 +1,5 @@
 #!/bin/sh
 # Check for active SSH connections/sessions *to* the system
 
-pgrep -f 'sshd:.*pts' >/dev/null && exit 254
+pgrep -f 'sshd(\.[^:]+)?:.*pts' >/dev/null && exit 254
 exit 0


### PR DESCRIPTION
Alpine Linux uses binaries named sshd.pam or sshd.krb5 depending on whether
the UsePAM or KerberosAuthentication or GSSAPIAuthentication options in
sshd_config are enabled.

So this change relaxes the pgrep pattern to also match these names.

Ref: https://gitlab.alpinelinux.org/alpine/aports/-/blob/0f365d899da2f684fa4ec235d221a8fb5b92e70d/main/openssh/sshd.initd#L87-91