### PR TITLE
Quit if system doesn't support any sleep states

### DIFF
--- a/sleep_inhibitor.py
+++ b/sleep_inhibitor.py
@@ -111,6 +111,14 @@ class Plugin:
 
 def init():
     'Program initialisation'
+
+    # Don't run if the system does not support sleep
+    with open("/sys/power/state") as f:
+        states = f.read()
+    if states is '':
+        print("System does not support any sleep states, quitting.")
+        sys.exit(0)
+
     # Process command line options
     opt = argparse.ArgumentParser(description=__doc__.strip())
     opt.add_argument('-c', '--config',


### PR DESCRIPTION
The motivation behind this is to help slow systems on battery power save
energy in cases where they do not support suspend but the distro/DE is
installing/starting sleep-inhibitor anyways.

This application can burn CPU cycles when the system is idle doing all
the various checks in the plugins. It's not a terrible amount of usage,
but every little bit helps.

In cases where sleep states are listed in sysfs, the app should continue
to work exactly as it did before.