### PR TITLE
ssh-session-open: Check for OpenSSH 9.8 sshd-session

### DIFF
--- a/sleep_inhibitor/plugins/ssh-session-open
+++ b/sleep_inhibitor/plugins/ssh-session-open
@@ -1,5 +1,5 @@
 #!/bin/sh
 # Check for active SSH connections/sessions *to* the system
 
-pgrep -f 'sshd(\.[^:]+)?:.*pts' >/dev/null && exit 254
+pgrep -f 'sshd(-session)?(\.[^:]+)?:.*pts' >/dev/null && exit 254
 exit 0


### PR DESCRIPTION
Since OpenSSH 9.8 open sessions are managed by a separate `sshd-session` binary instead of `sshd` (see [release notes](https://www.openssh.com/txt/release-9.8) under "Potentially-incompatible changes"), so update the regex in `ssh-session-open` to match the new binary. Keeping the "-session" part optional preserves compatibility with OpenSSH <= 9.7.